### PR TITLE
new styled -comp for selectedTimeBtn solves BUG

### DIFF
--- a/app/components/BookTableForm.tsx
+++ b/app/components/BookTableForm.tsx
@@ -28,7 +28,6 @@ export const BookTableForm = ({ restaurantId }: { restaurantId: string }) => {
   const [booking, setBooking] = useState(false);
   const [confirmedBooking, setConfirmedBooking] = useState(false);
 
-
   function handleChangeCustomerForm(e: ChangeEvent<HTMLInputElement>) {
     const name = e.target.name;
     setCustomerInput({ ...customerInput, [name]: e.target.value });

--- a/app/components/TimeSelectionForm.tsx
+++ b/app/components/TimeSelectionForm.tsx
@@ -1,7 +1,6 @@
 import { FormEvent } from "react";
 import { Form } from "./styled/Forms";
-import { SubmitButton, TimeButton } from "./styled/Buttons";
-import { availableParallelism } from "os";
+import { SubmitButton, TimeButton, SelectedTimeButton } from "./styled/Buttons";
 
 interface ITimeSelectionFormProps {
   handleTime: (time: string) => void;
@@ -44,20 +43,20 @@ export const TimeSelectionForm = ({
       <Form onSubmit={handleBooking}>
         {timeSelectionMessage()}
         <div className="btn-wrapper">
-          <TimeButton
-            isSelected={selectedTime === "18:00"}
+          <SelectedTimeButton
+            selected={selectedTime === "18:00"}
             onClick={() => handleTime("18:00")}
             disabled={!is18Available}
           >
             18:00
-          </TimeButton>
-          <TimeButton
-            isSelected={selectedTime === "21:00"}
+          </SelectedTimeButton>
+          <SelectedTimeButton
+            selected={selectedTime === "21:00"}
             onClick={() => handleTime("21:00")}
             disabled={!is21Available}
           >
             21:00
-          </TimeButton>
+          </SelectedTimeButton>
         </div>
         {selectedTime && (
           <div className="confirmation-div">

--- a/app/components/styled/Buttons.tsx
+++ b/app/components/styled/Buttons.tsx
@@ -78,7 +78,7 @@ export const SubmitButton = styled(Button)`
   }
 `;
 
-export const TimeButton = styled(Button)<{ isSelected: boolean }>`
+export const TimeButton = styled(Button)`
   width: 45%;
   display: inline;
   font-weight: bold;
@@ -109,9 +109,11 @@ export const TimeButton = styled(Button)<{ isSelected: boolean }>`
       color: ${grey300};
     }
   }
+`;
 
+export const SelectedTimeButton = styled(TimeButton)<{ selected?: boolean }>`
   ${(props) =>
-    props.isSelected &&
+    props.selected &&
     css`
       background-color: ${accent4};
       color: ${grey700};


### PR DESCRIPTION
BUG solved for renderDOM issues with styled-components TimeButton with props:
pass down new props as it's own component based on the base TimeButton.
when clicked/choosen: selected as props is added, Showing SelectedTimeButton w it's props, otherwise: just TimeButton.

** Please close branch when merged

<img width="463" alt="printscreen" src="https://github.com/jenmwa/therestaurant/assets/113125376/8ee3c1cb-33bd-4102-bf5d-3f32472abb55">
